### PR TITLE
Bumping Minor Version & Adding Some Basic Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [0.4.0] - 2025-08-13
+### Added
+- **Persistent Catalog Storage (JSON)**  
+  - FerriteDB now saves the table catalog (schemas) to `catalog.json` whenever tables are created or dropped.
+  - The catalog is automatically loaded at startup, so table definitions survive restarts without needing to recreate them manually.
+  - Uses a human-readable JSON format for easy inspection and debugging.
+
+### Changed
+- Updated internal `Catalog` struct to derive `Serialize` and `Deserialize` so schemas can be stored on disk.
+- `main.rs` now loads the catalog from disk if available; falls back to an empty catalog otherwise.
+
+### Developer Notes
+- The catalog file is stored in the same directory as your database `.tbl` files.
+- JSON was chosen over binary encoding to make debugging and manual editing easier.
+- Future schema changes may require migration logic, but JSON format makes this simpler.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# FerriteDB
+
+FerriteDB is an experimental relational database engine written in Rust.
+
+## Features
+- SQL parsing
+- In-memory data storage
+- Configurable row-based or columnar storage (planned)
+- JSON-based catalog storage (since v0.4.0)
+
+## Installation
+Clone the repository:
+```bash
+git clone https://github.com/yourusername/ferritedb.git
+```
+
+Run FerriteDB
+```bash
+cd ferrite-db
+cargo run
+```
+
+Create a table
+```bash
+Welcome to ferrite-db!
+> create table popular_databases (id int, name text, rank int);
+Table created: popular_databases
+```
+
+Insert into a table
+```bash
+> insert into popular_databases values (1, Oracle, 1);
+Inserted into popular_databases
+> insert into popular_databases values (2, MySQL, 2);
+Inserted into popular_databases
+> insert into popular_databases values (3, PostgreSQL, 3);
+Inserted into popular_databases
+```
+
+Select from a table
+```bash
+> select * from popular_databases;
+["1", "Oracle", "1"]
+["2", "MySQL", "2"]
+["4", "PostgreSQL", "4"]
+```
+
+View the catalog.json file
+```json
+{
+  "popular_databases": {
+    "name": "popular_databases",
+    "columns": [
+      {
+        "name": "id",
+        "data_type": "INT"
+      },
+      {
+        "name": "name",
+        "data_type": "TEXT"
+      },
+      {
+        "name": "rank",
+        "data_type": "INT"
+      }
+    ]
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Select from a table
 > select * from popular_databases;
 ["1", "Oracle", "1"]
 ["2", "MySQL", "2"]
-["4", "PostgreSQL", "4"]
+["3", "PostgreSQL", "3"]
 ```
 
 View the catalog.json file

--- a/ferrite-db/Cargo.lock
+++ b/ferrite-db/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ferrite-db"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "lazy_static",

--- a/ferrite-db/Cargo.toml
+++ b/ferrite-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrite-db"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

This pull request introduces persistent catalog storage to FerriteDB, allowing table schemas to be saved and reloaded automatically using a human-readable JSON file. It also updates the documentation to reflect this new feature and bumps the version to v0.4.0.

Persistent catalog storage:

* FerriteDB now saves the table catalog (schemas) to a `catalog.json` file whenever tables are created or dropped, and loads it at startup so table definitions persist across restarts. The catalog uses a human-readable JSON format for easy inspection and debugging. (`CHANGELOG.md`, `README.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R69)

Documentation updates:

* The `README.md` has been updated to describe the new persistent catalog feature, including an example of the `catalog.json` file and revised usage instructions.
* The changelog (`CHANGELOG.md`) has been created/updated to document the new features and internal changes for version 0.4.0.

Version bump:

* The crate version in `Cargo.toml` has been updated from 0.3.0 to 0.4.0 to reflect these changes.

## Checklist

- [X] Code compiles and runs
- [ ] Tests added/updated (if applicable)
- [X] Docs updated (if needed)
